### PR TITLE
rubyのバージョンを記載する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,13 @@
 source 'https://rubygems.org'
+
+ruby '3.2.2'
+
 gem 'sinatra'
 gem 'json'
 gem 'puma'
+
 group :development, :test do
-  gem 'rspec'        # RSpecの基本バージョン
-  gem 'rack-test'    # SinatraのHTTPリクエストテスト用
+  gem 'rspec'
+  gem 'rack-test'
   # その他のテスト関連のgemをここに追加
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,5 +44,8 @@ DEPENDENCIES
   rspec
   sinatra
 
+RUBY VERSION
+   ruby 3.2.2p53
+
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
deploy時にrubyのバージョンを記載するように警告が出るのでgemfileに記載した。